### PR TITLE
add deploy pipeline to heroku

### DIFF
--- a/.semaphore/deploy-heroku.yml
+++ b/.semaphore/deploy-heroku.yml
@@ -1,0 +1,41 @@
+# .semaphore/deploy-heroku.yml
+
+version: v1.0
+name: Deploy to Heroku
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
+blocks:
+  - name: Deploy to Heroku
+    task:
+      secrets:
+        # Make credentials available to jobs for MongoDB Atlas, 
+        # Docker Hub and Heroku.
+        # For info on creating secrets, see:
+        # https://docs.semaphoreci.com/article/66-environment-variables-and-secrets
+        - name: mongodb-atlas
+        - name: pyflask-semaphore
+        - name: heroku
+      # Define the Heroku application name
+      # For info on environment variables, see:
+      # https://docs.semaphoreci.com/article/66-environment-variables-and-secrets
+      env_vars:
+        - name: HEROKU_APP
+          value: YOUR_APP_NAME
+      jobs:
+        - name: Deploy
+          commands:
+            - checkout
+            # login to Docker Hub and pull the image
+            - echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin
+            - docker pull "$DOCKER_USERNAME"/pyflasksemaphore:$SEMAPHORE_WORKFLOW_ID
+            # push the image to Heroku registry
+            - heroku container:login
+            - docker tag "$DOCKER_USERNAME"/pyflasksemaphore:$SEMAPHORE_WORKFLOW_ID registry.heroku.com/$HEROKU_APP/web
+            - docker push registry.heroku.com/$HEROKU_APP/web
+            # define environment variable for MongoDB connection
+            - heroku config:set DB="$MONGODB_URI"
+            # release the app to production
+            - heroku stack:set container --app $HEROKU_APP
+            - heroku container:release web --app $HEROKU_APP

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -52,4 +52,13 @@ blocks:
         commands:
           - docker exec -it semaphore-pyflask-docker_flasksemaphore_1 python -m unittest
 
-      
+# Automatically deploy to Heroku on successful builds on master branch:
+# For info on promotions, see:
+# https://docs.semaphoreci.com/article/50-pipeline-yaml#promotions
+promotions:
+  - name: Deploy to Heroku
+    pipeline_file: deploy-heroku.yml
+    auto_promote_on:
+      - result: passed
+        branch:
+          - master

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -52,13 +52,9 @@ blocks:
         commands:
           - docker exec -it semaphore-pyflask-docker_flasksemaphore_1 python -m unittest
 
-# Automatically deploy to Heroku on successful builds on master branch:
+# Manual deployment to Heroku on successful builds on master branch:
 # For info on promotions, see:
 # https://docs.semaphoreci.com/article/50-pipeline-yaml#promotions
 promotions:
   - name: Deploy to Heroku
     pipeline_file: deploy-heroku.yml
-    auto_promote_on:
-      - result: passed
-        branch:
-          - master

--- a/flask.Dockerfile
+++ b/flask.Dockerfile
@@ -4,4 +4,4 @@ WORKDIR /opt/
 EXPOSE 5000
 RUN pip install --upgrade pip
 RUN pip install -r requirements.txt
-ENTRYPOINT ["python","run.py"]
+CMD ["python","run.py"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ Flask_WTF==0.14.2
 pymongo==3.7.2
 Flask_PyMongo==2.2.0
 Flask==1.0.2
+dnspython==1.16.0

--- a/run.py
+++ b/run.py
@@ -1,4 +1,6 @@
 from semaphoreflask import app
+import os
 
 if __name__ == '__main__':
-    app.run(debug=True, host='0.0.0.0')
+    port = os.getenv('PORT',5000)
+    app.run(debug=True, host='0.0.0.0', port=port)


### PR DESCRIPTION
Modifications:

- New heroku deployment pipeline, with auto promotion for master 
- New secret for Heroku 
- New secret for MongoDB Atlas
- New environment variable $HEROKU_APP
- flask.Dockerfile: Replaced ENTRYPOINT with CMD in. It seems that Heroku doesn't support ENTRYPOINT.
- run.py now looks for $PORT to bind, as required by Heroku. If not defined, defaults to 5000.
- requirements.txt: added dnspython, required to connect MongoDB Atlas.