### PR TITLE
add support for MONGODB_URL env

### DIFF
--- a/semaphoreflask/__init__.py
+++ b/semaphoreflask/__init__.py
@@ -4,7 +4,7 @@ import os
 
 app = Flask('__name__', template_folder="./semaphoreflask/templates/")
 app.config['SECRET_KEY'] = 'b6b462cf486aa21eee5719bf931a792e'
-app.config["MONGO_URI"] = os.environ['DB']
+app.config["MONGO_URI"] = os.environ.get('DB') or os.environ.get('MONGODB_URI')
 
 try:
     mongo = PyMongo(app)


### PR DESCRIPTION
add support for MONGODB_URL environment variable (the default). This allows tighter integration with mLab on Heroku